### PR TITLE
feat: Add nsip-skills to automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
     outputs:
       client_changed: ${{ steps.changes.outputs.client }}
       server_changed: ${{ steps.changes.outputs.server }}
-      any_changed: ${{ steps.changes.outputs.client == 'true' || steps.changes.outputs.server == 'true' }}
+      skills_changed: ${{ steps.changes.outputs.skills }}
+      any_changed: ${{ steps.changes.outputs.client == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.skills == 'true' }}
 
     steps:
     - name: Checkout code
@@ -38,6 +39,9 @@ jobs:
           server:
             - 'src/nsip_mcp/**'
             - 'packaging/nsip-mcp-server/**'
+          skills:
+            - 'src/nsip_skills/**'
+            - 'packaging/nsip-skills/**'
 
   bump-and-tag:
     name: Bump Version and Tag
@@ -47,6 +51,7 @@ jobs:
     outputs:
       client_version: ${{ steps.versions.outputs.client_version }}
       server_version: ${{ steps.versions.outputs.server_version }}
+      skills_version: ${{ steps.versions.outputs.skills_version }}
       release_tag: ${{ steps.versions.outputs.release_tag }}
 
     steps:
@@ -66,16 +71,33 @@ jobs:
       env:
         CLIENT_CHANGED: ${{ needs.detect-changes.outputs.client_changed }}
         SERVER_CHANGED: ${{ needs.detect-changes.outputs.server_changed }}
+        SKILLS_CHANGED: ${{ needs.detect-changes.outputs.skills_changed }}
       run: |
-        if [ "$CLIENT_CHANGED" = "true" ] && [ "$SERVER_CHANGED" = "true" ]; then
-          echo "Bumping both packages"
-          python scripts/bump_version.py --package both --bump patch
+        # Determine which packages to bump based on changes
+        if [ "$CLIENT_CHANGED" = "true" ] && [ "$SERVER_CHANGED" = "true" ] && [ "$SKILLS_CHANGED" = "true" ]; then
+          echo "Bumping all packages"
+          python scripts/bump_version.py --package all --bump patch
+        elif [ "$CLIENT_CHANGED" = "true" ] && [ "$SERVER_CHANGED" = "true" ]; then
+          echo "Bumping client and server"
+          python scripts/bump_version.py --package client --bump patch
+          python scripts/bump_version.py --package server --bump patch
+        elif [ "$CLIENT_CHANGED" = "true" ] && [ "$SKILLS_CHANGED" = "true" ]; then
+          echo "Bumping client and skills"
+          python scripts/bump_version.py --package client --bump patch
+          python scripts/bump_version.py --package skills --bump patch
+        elif [ "$SERVER_CHANGED" = "true" ] && [ "$SKILLS_CHANGED" = "true" ]; then
+          echo "Bumping server and skills"
+          python scripts/bump_version.py --package server --bump patch
+          python scripts/bump_version.py --package skills --bump patch
         elif [ "$CLIENT_CHANGED" = "true" ]; then
           echo "Bumping client only"
           python scripts/bump_version.py --package client --bump patch
         elif [ "$SERVER_CHANGED" = "true" ]; then
           echo "Bumping server only"
           python scripts/bump_version.py --package server --bump patch
+        elif [ "$SKILLS_CHANGED" = "true" ]; then
+          echo "Bumping skills only"
+          python scripts/bump_version.py --package skills --bump patch
         fi
 
     - name: Extract versions
@@ -83,14 +105,13 @@ jobs:
       run: |
         CLIENT_VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/nsip_client/__init__.py)
         SERVER_VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/nsip_mcp/__init__.py)
+        SKILLS_VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/nsip_skills/__init__.py)
         echo "client_version=$CLIENT_VERSION" >> "$GITHUB_OUTPUT"
         echo "server_version=$SERVER_VERSION" >> "$GITHUB_OUTPUT"
-        # Use the higher version as the release tag
-        if [ "$(printf '%s\n' "$CLIENT_VERSION" "$SERVER_VERSION" | sort -V | tail -n1)" = "$CLIENT_VERSION" ]; then
-          echo "release_tag=v$CLIENT_VERSION" >> "$GITHUB_OUTPUT"
-        else
-          echo "release_tag=v$SERVER_VERSION" >> "$GITHUB_OUTPUT"
-        fi
+        echo "skills_version=$SKILLS_VERSION" >> "$GITHUB_OUTPUT"
+        # Use the highest version as the release tag
+        HIGHEST=$(printf '%s\n' "$CLIENT_VERSION" "$SERVER_VERSION" "$SKILLS_VERSION" | sort -V | tail -n1)
+        echo "release_tag=v$HIGHEST" >> "$GITHUB_OUTPUT"
 
     - name: Commit version changes
       run: |
@@ -145,6 +166,12 @@ jobs:
         cp dist/* ../../dist/
         cd ../..
 
+        # Build skills
+        cd packaging/nsip-skills
+        python -m build
+        cp dist/* ../../dist/
+        cd ../..
+
         # Verify all packages
         twine check dist/*
 
@@ -152,9 +179,6 @@ jobs:
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_TAG: ${{ needs.bump-and-tag.outputs.release_tag }}
-        CLIENT_VERSION: ${{ needs.bump-and-tag.outputs.client_version }}
-        SERVER_VERSION: ${{ needs.bump-and-tag.outputs.server_version }}
       with:
         tag_name: ${{ needs.bump-and-tag.outputs.release_tag }}
         name: Release ${{ needs.bump-and-tag.outputs.release_tag }}
@@ -163,6 +187,7 @@ jobs:
 
           - **nsip-client**: ${{ needs.bump-and-tag.outputs.client_version }}
           - **nsip-mcp-server**: ${{ needs.bump-and-tag.outputs.server_version }}
+          - **nsip-skills**: ${{ needs.bump-and-tag.outputs.skills_version }}
 
           ## Installation
 
@@ -172,6 +197,9 @@ jobs:
 
           # Install the MCP server (includes client as dependency)
           pip install ./nsip_mcp_server-${{ needs.bump-and-tag.outputs.server_version }}-py3-none-any.whl
+
+          # Install the breeding tools (includes client as dependency)
+          pip install ./nsip_skills-${{ needs.bump-and-tag.outputs.skills_version }}-py3-none-any.whl
           ```
 
           ## Changes
@@ -184,8 +212,6 @@ jobs:
 
     - name: Upload release artifacts
       uses: actions/upload-artifact@v4
-      env:
-        RELEASE_TAG: ${{ needs.bump-and-tag.outputs.release_tag }}
       with:
         name: release-${{ needs.bump-and-tag.outputs.release_tag }}
         path: dist/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [nsip-skills 1.3.0] - 2025-12-06
+
+### Added
+
+#### NSIP Skills Package - Initial Release
+Breeding decision support tools for sheep genetics using NSIP data.
+
+- **10 Analysis Modules**:
+  1. `flock_import` - Import and enrich flock data from spreadsheets with NSIP breeding values
+  2. `ebv_analysis` - Compare and rank animals by EBV traits
+  3. `inbreeding` - Calculate pedigree-based inbreeding coefficients
+  4. `mating_optimizer` - Recommend optimal ram-ewe pairings
+  5. `progeny_analysis` - Evaluate sires by offspring performance
+  6. `trait_planner` - Design multi-generation improvement strategies
+  7. `ancestry_builder` - Generate pedigree reports and visualizations
+  8. `flock_stats` - Calculate aggregate flock statistics
+  9. `selection_index` - Build and apply custom breeding indexes
+  10. `recommendation_engine` - AI-powered breeding recommendations
+
+- **9 CLI Entry Points**:
+  - `nsip-ebv-analysis` - Compare and analyze EBV traits
+  - `nsip-flock-import` - Import flock data from spreadsheets
+  - `nsip-flock-stats` - Generate flock statistics
+  - `nsip-inbreeding` - Calculate inbreeding coefficients
+  - `nsip-mating-optimizer` - Generate mating recommendations
+  - `nsip-progeny-analysis` - Analyze progeny performance
+  - `nsip-trait-planner` - Plan trait improvement strategies
+  - `nsip-ancestry` - Build ancestry/pedigree reports
+  - `nsip-selection-index` - Calculate selection indexes
+
+- **Common Utilities**:
+  - `CachedNSIPClient` - Wrapper with caching for NSIP API calls
+  - Data models: `AnimalAnalysis`, `FlockSummary`, `InbreedingResult`, `MatingPair`, `PedigreeTree`, `TraitProfile`
+
+- **Optional Dependencies**:
+  - `gsheets` extra for Google Sheets integration via `gspread`
+
+### Dependencies
+- `nsip-client>=1.3.0,<2.0.0` (core API client)
+- `pandas>=2.0.0` (data manipulation)
+- `numpy>=1.24.0` (numerical operations)
+- `openpyxl>=3.1.0` (Excel file support)
+
+### Installation
+```bash
+# Basic installation
+pip install nsip-skills
+
+# With Google Sheets support
+pip install nsip-skills[gsheets]
+```
+
 ## [1.2.0] - 2025-10-13
 
 ### Changed

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -4,9 +4,10 @@
 Usage:
     python scripts/bump_version.py --package client --bump patch
     python scripts/bump_version.py --package server --bump patch
-    python scripts/bump_version.py --package both --bump minor
+    python scripts/bump_version.py --package skills --bump patch
+    python scripts/bump_version.py --package all --bump minor
 
-For minor/major bumps, both packages are aligned to the same version.
+For minor/major bumps, all packages are aligned to the same version.
 For patch bumps, only the specified package is incremented.
 """
 
@@ -21,10 +22,13 @@ PROJECT_ROOT = Path(__file__).parent.parent
 # Package paths
 CLIENT_INIT = PROJECT_ROOT / "src" / "nsip_client" / "__init__.py"
 SERVER_INIT = PROJECT_ROOT / "src" / "nsip_mcp" / "__init__.py"
+SKILLS_INIT = PROJECT_ROOT / "src" / "nsip_skills" / "__init__.py"
 SERVER_PYPROJECT = PROJECT_ROOT / "packaging" / "nsip-mcp-server" / "pyproject.toml"
+SKILLS_PYPROJECT = PROJECT_ROOT / "packaging" / "nsip-skills" / "pyproject.toml"
 
 VERSION_PATTERN = re.compile(r'^__version__\s*=\s*["\'](\d+\.\d+\.\d+)["\']', re.MULTILINE)
-DEPENDENCY_PATTERN = re.compile(r'("nsip-client~=)(\d+\.\d+)(\.0")')
+# Match dependency format: "nsip-client>=1.3.0,<2.0.0"
+DEPENDENCY_PATTERN = re.compile(r'("nsip-client>=)(\d+\.\d+\.\d+)(,<\d+\.\d+\.\d+")')
 
 
 def read_version(init_path: Path) -> tuple[int, int, int]:
@@ -46,12 +50,14 @@ def write_version(init_path: Path, major: int, minor: int, patch: int) -> None:
     print(f"Updated {init_path.name}: {new_version}")
 
 
-def update_server_dependency(major: int, minor: int) -> None:
-    """Update nsip-client dependency pin in server's pyproject.toml."""
-    content = SERVER_PYPROJECT.read_text()
-    new_content = DEPENDENCY_PATTERN.sub(rf'\g<1>{major}.{minor}.0"', content)
-    SERVER_PYPROJECT.write_text(new_content)
-    print(f"Updated server dependency: nsip-client~={major}.{minor}.0")
+def update_dependency(pyproject_path: Path, major: int, minor: int, patch: int) -> None:
+    """Update nsip-client dependency pin in pyproject.toml."""
+    content = pyproject_path.read_text()
+    new_version = f"{major}.{minor}.{patch}"
+    new_content = DEPENDENCY_PATTERN.sub(rf'\g<1>{new_version}\g<3>', content)
+    if content != new_content:
+        pyproject_path.write_text(new_content)
+        print(f"Updated {pyproject_path.parent.name} dependency: nsip-client>={new_version}")
 
 
 def bump_version(
@@ -71,7 +77,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Bump package version(s)")
     parser.add_argument(
         "--package",
-        choices=["client", "server", "both"],
+        choices=["client", "server", "skills", "all"],
         required=True,
         help="Which package(s) to bump",
     )
@@ -88,34 +94,44 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    # For minor/major bumps, always bump both packages
-    if args.bump in ("minor", "major") and args.package != "both":
-        print(f"Note: {args.bump} bump requires aligning both packages")
-        args.package = "both"
+    # For minor/major bumps, always bump all packages
+    if args.bump in ("minor", "major") and args.package != "all":
+        print(f"Note: {args.bump} bump requires aligning all packages")
+        args.package = "all"
 
     # Read current versions
     client_version = read_version(CLIENT_INIT)
     server_version = read_version(SERVER_INIT)
+    skills_version = read_version(SKILLS_INIT)
 
     print(f"Current client version: {'.'.join(map(str, client_version))}")
     print(f"Current server version: {'.'.join(map(str, server_version))}")
+    print(f"Current skills version: {'.'.join(map(str, skills_version))}")
 
     # Calculate new versions
     if args.package == "client":
         new_client = bump_version(client_version, args.bump)
         new_server = server_version
+        new_skills = skills_version
     elif args.package == "server":
         new_client = client_version
         new_server = bump_version(server_version, args.bump)
-    else:  # both
-        # For aligned bumps, use the higher version as base
-        base = max(client_version, server_version)
+        new_skills = skills_version
+    elif args.package == "skills":
+        new_client = client_version
+        new_server = server_version
+        new_skills = bump_version(skills_version, args.bump)
+    else:  # all
+        # For aligned bumps, use the highest version as base
+        base = max(client_version, server_version, skills_version)
         new_version = bump_version(base, args.bump)
         new_client = new_version
         new_server = new_version
+        new_skills = new_version
 
     print(f"\nNew client version: {'.'.join(map(str, new_client))}")
     print(f"New server version: {'.'.join(map(str, new_server))}")
+    print(f"New skills version: {'.'.join(map(str, new_skills))}")
 
     if args.dry_run:
         print("\n[DRY RUN] No changes made")
@@ -128,9 +144,13 @@ def main() -> int:
     if new_server != server_version:
         write_version(SERVER_INIT, *new_server)
 
-    # Update server's dependency on client if client version changed
+    if new_skills != skills_version:
+        write_version(SKILLS_INIT, *new_skills)
+
+    # Update dependencies on client if client version changed
     if new_client != client_version or args.bump in ("minor", "major"):
-        update_server_dependency(new_client[0], new_client[1])
+        update_dependency(SERVER_PYPROJECT, *new_client)
+        update_dependency(SKILLS_PYPROJECT, *new_client)
 
     print("\nVersion bump complete!")
     return 0

--- a/src/nsip_skills/__init__.py
+++ b/src/nsip_skills/__init__.py
@@ -17,7 +17,7 @@ Available modules:
     - recommendation_engine: AI-powered breeding recommendations
 """
 
-__version__ = "1.0.0"
+__version__ = "1.3.0"
 
 # Re-export common utilities for convenience
 from nsip_skills.common.data_models import (


### PR DESCRIPTION
## Summary

- Add nsip-skills package detection in GitHub Actions release workflow
- Update `scripts/bump_version.py` to support `--package skills` and `--package all` options
- Update dependency pattern matching for the `>=x.y.z,<2.0.0` format
- Set nsip-skills initial version to 1.3.0 for consistency with nsip-client
- Add comprehensive CHANGELOG entry for nsip-skills 1.3.0 initial release
- Build and include nsip-skills wheel in GitHub releases

## Changes

### `.github/workflows/release.yml`
- Added `skills` filter in `detect-changes` job for `src/nsip_skills/**` and `packaging/nsip-skills/**`
- Added `skills_changed` output and updated `any_changed` condition
- Added `skills_version` output extraction
- Extended version bump logic to handle all package combinations
- Added skills package build step
- Updated release body to include nsip-skills version and installation instructions

### `scripts/bump_version.py`
- Added `SKILLS_INIT` and `SKILLS_PYPROJECT` path constants
- Added `skills` choice to `--package` argument
- Renamed `both` → `all` for three-package alignment
- Updated dependency pattern to match `>=x.y.z,<2.0.0` format
- Added skills version reading/writing
- Updated dependency pinning for both server and skills pyproject.toml

### `src/nsip_skills/__init__.py`
- Updated version from `1.0.0` to `1.3.0`

### `docs/CHANGELOG.md`
- Added nsip-skills 1.3.0 entry documenting:
  - 10 analysis modules
  - 9 CLI entry points
  - Common utilities and data models
  - Dependencies and installation instructions

## Test plan

- [x] Verify `bump_version.py --package skills --bump patch --dry-run` works correctly
- [x] Verify flake8 passes on modified files
- [ ] CI should pass (workflow syntax validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)